### PR TITLE
Add label_threshold_angle property to hide labels on small pie segments

### DIFF
--- a/SVGGraphPieGraph.php
+++ b/SVGGraphPieGraph.php
@@ -123,53 +123,58 @@ class PieGraph extends Graph {
 
       $t_style = NULL;
       if($this->show_labels) {
+        //Only draw the label if it's below the threshold angle
+        if (abs($angle_end - $angle_start) > deg2rad($this->label_threshold_angle)) {
+          $text['id'] = $this->NewID();
+          if ($this->label_fade_in_speed && $this->compat_events) {
+            $text['opacity'] = '0.0';
+          }
 
-        $text['id'] = $this->NewID();
-        if($this->label_fade_in_speed && $this->compat_events)
-          $text['opacity'] = '0.0';
+          // display however many lines of label
+          $label = $item->Data('label');
+          if (is_null($label)) {
+            $parts = array();
+            if ($this->show_label_key) {
+              $parts = explode("\n", $this->GetKey($this->values->AssociativeKeys() ?
+                  $original_position : $key));
+            }
+            if ($this->show_label_amount) {
+              $parts[] = $this->units_before_label . Graph::NumString($value) .
+                  $this->units_label;
+            }
+            if ($this->show_label_percent) {
+              $parts[] = Graph::NumString($value / $this->total * 100.0,
+                      $this->label_percent_decimals) . '%';
+            }
+          } else {
+            $parts = array($label);
+          }
+          $parts = implode("\n", $parts);
 
-        // display however many lines of label
-        $label = $item->Data('label');
-        if(is_null($label)) {
-          $parts = array();
-          if($this->show_label_key)
-            $parts = explode("\n", $this->GetKey($this->values->AssociativeKeys() ? 
-              $original_position : $key));
-          if($this->show_label_amount)
-            $parts[] = $this->units_before_label . Graph::NumString($value) .
-              $this->units_label;
-          if($this->show_label_percent)
-            $parts[] = Graph::NumString($value / $this->total * 100.0,
-              $this->label_percent_decimals) . '%';
-        } else {
-          $parts = array($label);
+          if ($vcount > 1) {
+            list($xc, $yc) = $this->GetLabelPosition($item, $angle_start, $angle_end,
+                $radius_x, $radius_y, $parts);
+          } else {
+            $xc = $yc = 0;
+          }
+          $tx = $this->x_centre + $xc;
+          $ty = $this->y_centre + $yc;
+
+          $text['x'] = $tx;
+          $text['y'] = $ty;
+          $text['fill'] = $this->label_colour;
+          if (!empty($this->label_back_colour)) {
+            $outline = array(
+                'stroke-width'    => '3px',
+                'stroke'          => $this->label_back_colour,
+                'stroke-linejoin' => 'round',
+            );
+            $t1 = array_merge($outline, $text);
+            $labels .= $this->Text($parts, $this->label_font_size, $t1);
+          }
+          $labels .= $this->Text($parts, $this->label_font_size, $text);
         }
-        $parts = implode("\n", $parts);
-
-        if($vcount > 1) {
-          list($xc, $yc) = $this->GetLabelPosition($item, $angle_start, $angle_end,
-            $radius_x, $radius_y, $parts);
-        } else {
-          $xc = $yc = 0;
-        }
-        $tx = $this->x_centre + $xc;
-        $ty = $this->y_centre + $yc;
-
-        $text['x'] = $tx;
-        $text['y'] = $ty;
-        $text['fill'] = $this->label_colour;
-        if(!empty($this->label_back_colour)) {
-          $outline = array(
-            'stroke-width' => '3px',
-            'stroke' => $this->label_back_colour,
-            'stroke-linejoin' => 'round',
-          );
-          $t1 = array_merge($outline, $text);
-          $labels .= $this->Text($parts, $this->label_font_size, $t1);
-        }
-        $labels .= $this->Text($parts, $this->label_font_size, $text);
       }
-
       if($radius_x || $radius_y) {
         if($this->show_tooltips)
           $this->SetTooltip($attr, $item, $key, $value, !$this->compat_events);

--- a/svggraph.ini
+++ b/svggraph.ini
@@ -368,6 +368,7 @@ show_labels = true
 show_label_key = true
 show_label_amount = false
 show_label_percent = false
+label_threshold_angle = 0
 label_percent_decimals = 2
 label_colour = "white"
 label_back_colour = null


### PR DESCRIPTION
I was running into a problem where a pie with lots of small segments had illegible labels because they all overlapped. This patch adds a `label_threshold_angle` settings property; if the angle subtended by a segment is below this value, the label is not shown. Internal calculations (`$start_angle` and `$end_angle`) use radians, but I made this property use degrees. For example:

```
'label_threshold_angle` => 20
```

would hide labels on all segments smaller than 20 degrees.

The patch only really adds a couple of lines - it looks like more because of indent changes.
